### PR TITLE
充分利用路径别名

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
-.vscode
+# .vscode
 .idea
 /packages
 **/.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "slint.libraryPaths": {
+    "ui": "ui\\",
+    "sui": "ui\\modules\\surrealism-ui\\",
+    "views": "ui\\views\\"
+  }
+}

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,10 @@
 fn main() {
-    slint_build::compile("ui/app.slint").unwrap();
+    let manifest_dir = std::path::PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let library_paths = std::collections::HashMap::from([
+        ("ui".into(), manifest_dir.join("ui")),
+        ("views".into(), manifest_dir.join("ui/views")),
+        ("sui".into(), manifest_dir.join("ui/modules/surrealism-ui")),
+    ]);
+    let config = slint_build::CompilerConfiguration::new().with_library_paths(library_paths);
+    slint_build::compile_with_config("ui/app.slint", config).unwrap();
 }

--- a/ui/app.slint
+++ b/ui/app.slint
@@ -1,9 +1,9 @@
-import {MainView} from "./index.slint";
-import {ROOT_GLOBAL} from "./global.slint";
+import { MainView } from "@views/main.slint";
+import { ROOT_GLOBAL } from "@ui/global.slint";
 
 export component App inherits Window {
-  height: ROOT-GLOBAL.window-height;
-  width: ROOT-GLOBAL.window-width;
-  title: @tr("Slint + SurrealismUI + Rust");
-  MainView {}
+    height: ROOT-GLOBAL.window-height;
+    width: ROOT-GLOBAL.window-width;
+    title: @tr("Slint + SurrealismUI + Rust");
+    MainView { }
 }

--- a/ui/global.slint
+++ b/ui/global.slint
@@ -1,7 +1,7 @@
 //! global styles
 export global ROOT_GLOBAL {
-  in-out property <length> window-height : 600px;
-  in-out property <length> window-width : 800px;
-  in-out property <length> font-size : 16px;
-  in-out property <length> padding : 0px;
+    in-out property <length> window-height: 600px;
+    in-out property <length> window-width: 800px;
+    in-out property <length> font-size: 16px;
+    in-out property <length> padding: 0px;
 }

--- a/ui/index.slint
+++ b/ui/index.slint
@@ -1,2 +1,0 @@
-//export views
-export * from "./views/index.slint";

--- a/ui/views/index.slint
+++ b/ui/views/index.slint
@@ -1,6 +1,0 @@
-//! export views
-//! you should export all views here
-
-import { MainView } from "./main.slint";
-
-export { MainView }

--- a/ui/views/main.slint
+++ b/ui/views/main.slint
@@ -1,16 +1,17 @@
-import {Hello} from "../components/index.slint";
-import { SButton } from "../modules/surrealism-ui/index.slint";
+import { Hello } from "@ui/components/index.slint";
+import { SButton } from "@sui/index.slint";
 
 export component MainView {
-  height: 100%;
-  width: 100%;
-  VerticalLayout {
-    Hello{}
-    Rectangle {
-      SButton {
-        theme:Dark;
-        text: "Click Me!";
-      }
+    height: 100%;
+    width: 100%;
+    VerticalLayout {
+        Hello { }
+
+        Rectangle {
+            SButton {
+                theme: Dark;
+                text: "Click Me!";
+            }
+        }
     }
-  }
 }


### PR DESCRIPTION
有三个建议希望作者能参考参考🌹

第一个是，建议加入合适的路径别名配置
(这需要将.vscode加入版本管理，确保插件能预览，还有需要在build.rs中加入别名的编译配置)

第二是，减少不太必要的重新导出，我觉得模板里的重新导出有点过于复杂了，毕竟slint不像vite一样，vite不需要把index.js或index.ts写出来，而slint必须写出index.slint。过渡的重新导出并不见得更简洁明了()

第三是，vscode中的slint插件支持slint代码的格式化，建议将代码进行格式化，统一缩进。