### PR TITLE
address issue #3: cargo-generate substitution error on png file

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,4 @@
+[template]
+ignore = [ 
+    "ui/assets/surrealism.png",
+]


### PR DESCRIPTION
cargo-generate on the surrealism-ui-template generates substitution errors on surrealism.png  (See issue #3).
Adding ```cargo-generate.toml``` with ui/asset/surrealism.png as an exclusion rule will skip substitution for this file.
Tested on Fedora 42.