### PR TITLE
Adds ui/assets/surrealism.png to exclusion list in cargo-generate.toml

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,4 +1,4 @@
 [template]
-ignore = [ 
+exclude = [ 
     "ui/assets/surrealism.png",
 ]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,4 @@
+[template]
+ignore = [ 
+    "ui/assets/surrealism.png",
+]


### PR DESCRIPTION
Refer issue #3.   Adds new cargo-generate.toml file.  Adds ui/assets/surrealism.png to exclusion list for cargo-generate substitutions.  Tested on Fedora 42.